### PR TITLE
feat: return error message for VSF notification component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@headlesscommerce/vsf-magento-stripe",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Stripe Payment module for Vue Storefront Magento",
   "main": "index.js",
   "modules": "index.js",

--- a/stripe/components/Payment.vue
+++ b/stripe/components/Payment.vue
@@ -91,7 +91,7 @@
         });
 
         if (confirmPayment.error) {
-          throw(confirmPayment.error);
+          return confirmPayment.error;
         }
 
         if (confirmPayment.paymentIntent.status === "succeeded") {


### PR DESCRIPTION
Instead of throwing error return the error from Stripe to pass the error message to SfNotification component.