### PR TITLE
Use prop rather than env variable for api key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@headlesscommerce/vsf-magento-stripe",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Stripe Payment module for Vue Storefront Magento",
   "main": "index.js",
   "modules": "index.js",

--- a/stripe/components/Payment.vue
+++ b/stripe/components/Payment.vue
@@ -28,10 +28,16 @@
       StripeElementPayment
     },
     emits: ['status'],
-    setup(_props, { emit }) {
+    props: {
+      apiKey: {
+        type: String,
+        default: '',
+      },
+    },
+    setup(props, { emit }) {
       const { load, save } = usePaymentProvider();
       const paymentRef = ref(null);
-      const publishableKey = process.env.STRIPE_PUBLISHABLE_KEY;
+      const publishableKey = props.apiKey;
       const paymentMethods = ref(null);
       const { cart } = useCart();
       const elementsOptions = ref<PaymentIntentOptions>();


### PR DESCRIPTION
Parse api key via props rather the env variable. As there could be apps that are not relying on env variables.